### PR TITLE
fix: make rule severity explicit and stabilize PPY049

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -34,97 +34,97 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY002 — Exception.add_note() requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY003 — X | Y union type syntax requires Python 3.10+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY004 — tomllib requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY005 — match/case requires Python 3.10+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY006 — asyncio.timeout() / TaskGroup requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY007 — Module removed in Python 3.13
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY008 — __slots__ may not prevent __dict__ on Python < 3.10
 
-**Severity:** Warning | **Confidence:** Medium | **Affects:** CPython
+**Severity:** Info | **Confidence:** Medium | **Affects:** CPython
 
 ---
 ### CPY009 — ExceptionGroup requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY010 — @dataclass(slots=True) requires Python 3.10+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY011 — typing.Self requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY012 — typing.LiteralString requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY013 — typing.override requires Python 3.12+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY014 — typing.TypeAlias requires Python 3.10+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY015 — typing.Never requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY016 — typing.TypeVarTuple requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY017 — typing.Unpack requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY018 — typing.Required / NotRequired requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY019 — distutils removed in Python 3.12+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY020 — datetime.UTC requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY022 — Bitwise inversion on bool (~True/~False) deprecated in 3.12
@@ -139,27 +139,27 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY024 — typing.TypeGuard requires Python 3.10+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY025 — typing.ParamSpec requires Python 3.10+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY026 — typing.io and typing.re removed in Python 3.13
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY027 — locale.resetlocale() removed in Python 3.13
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY028 — lib2to3 removed in Python 3.13
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY029 — locals() semantics changed in Python 3.13 (PEP 667)
@@ -169,32 +169,32 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY030 — sys.path no longer accepts bytes entries in Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY031 — typing.assert_never requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY032 — typing.reveal_type requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY033 — pathlib.Path.is_relative_to() requires Python 3.9+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY034 — int.bit_count() requires Python 3.10+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY035 — str.removeprefix/removesuffix requires Python 3.9+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY036 — datetime.utcnow() deprecated since Python 3.12
@@ -209,37 +209,37 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY038 — asyncio.get_event_loop() raises RuntimeError in Python 3.14+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY039 — zoneinfo module requires Python 3.9+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY040 — graphlib module requires Python 3.9+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY041 — dict | merge operator requires Python 3.9+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY042 — aiter() and anext() builtins require Python 3.10+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY043 — math.lcm() requires Python 3.9+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY044 — math.gcd() with multiple args requires Python 3.9+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY045 — NaN hash behaviour changed in Python 3.10
@@ -259,12 +259,12 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY048 — concurrent.interpreters requires Python 3.14+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY049 — compression.zstd requires Python 3.14+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY050 — PurePath.is_reserved() deprecated in 3.13, removed in 3.15
@@ -279,17 +279,17 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY053 — typing.get_overloads() requires Python 3.11+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY054 — int() no longer delegates to __trunc__() in Python 3.14
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY055 — NotImplemented in boolean context raises TypeError in Python 3.14
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY057 — pickle default protocol changed to 5 in Python 3.14
@@ -299,32 +299,32 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY062 — string.templatelib requires Python 3.14+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY063 — annotationlib requires Python 3.14+
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY064 — Deprecated AST node types removed in Python 3.14
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY065 — pkgutil.find_loader()/get_loader() removed in Python 3.14
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY066 — asyncio child watcher classes removed in Python 3.14
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY067 — typing.NamedTuple keyword syntax removed in Python 3.15
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY068 — typing.no_type_check_decorator deprecated in 3.13, removed in 3.15
@@ -344,17 +344,17 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY071 — pty.master_open()/slave_open() removed in Python 3.14
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY072 — importlib.abc resource classes removed in Python 3.14
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY073 — sqlite3.version/version_info removed in Python 3.14
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY074 — code.__lnotab__ deprecated since Python 3.10 (PEP 626)
@@ -369,12 +369,12 @@ These rules detect code that behaves differently across CPython versions.
 ---
 ### CPY076 — ssl.wrap_socket() removed in Python 3.12
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 ### CPY077 — typing.TypedDict zero-field syntax removed in Python 3.15
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython
+**Severity:** Error | **Confidence:** High | **Affects:** CPython
 
 ---
 
@@ -386,7 +386,7 @@ These rules detect code that behaves differently on PyPy vs CPython.
 
 ### PPY001 — Relying on __del__ for resource cleanup breaks on PyPy
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Error | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY002 — ctypes usage may silently fail on PyPy
@@ -396,7 +396,7 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY003 — sys.getrefcount() is meaningless on PyPy
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Error | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY004 — weakref.proxy() lifetime differs on PyPy due to GC model
@@ -416,7 +416,7 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY007 — sys.intern() identity guarantees differ on PyPy
 
-**Severity:** Warning | **Confidence:** Low | **Affects:** PyPy
+**Severity:** Info | **Confidence:** Low | **Affects:** PyPy
 
 ---
 ### PPY008 — threading.local() cleanup timing differs on PyPy
@@ -441,7 +441,7 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY013 — sys.getsizeof() raises TypeError on PyPy
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Error | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY014 — String concatenation in loop is O(n²) on PyPy
@@ -461,7 +461,7 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY017 — Adding __del__ to existing class not called on PyPy
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Error | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY018 — sys.setrecursionlimit() behaviour differs on PyPy
@@ -491,7 +491,7 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY024 — timeit reports average not minimum on PyPy
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Info | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY025 — Set iteration order differs between CPython and PyPy
@@ -506,7 +506,7 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY027 — Deleting module/class attributes may be slower on PyPy
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Info | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY028 — readline.parse_and_bind() silently ignored on PyPy
@@ -541,7 +541,7 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY034 — hash() values may differ between CPython and PyPy
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Info | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY035 — C extension packages may not work correctly on PyPy
@@ -556,12 +556,12 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY037 — os.urandom() source may differ on PyPy
 
-**Severity:** Warning | **Confidence:** Low | **Affects:** PyPy
+**Severity:** Info | **Confidence:** Low | **Affects:** PyPy
 
 ---
 ### PPY038 — decimal module uses different backend on PyPy
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Info | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY039 — os.fork() may not work correctly on all PyPy platforms
@@ -576,17 +576,17 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY041 — dict | operator requires PyPy 7.3.7+ (Python 3.9 compat)
 
-**Severity:** Warning | **Confidence:** High | **Affects:** PyPy
+**Severity:** Info | **Confidence:** High | **Affects:** PyPy
 
 ---
 ### PPY042 — print(flush=True) may not flush immediately on PyPy
 
-**Severity:** Warning | **Confidence:** Low | **Affects:** PyPy
+**Severity:** Info | **Confidence:** Low | **Affects:** PyPy
 
 ---
 ### PPY044 — Exception variable cleanup timing differs on PyPy
 
-**Severity:** Warning | **Confidence:** Medium | **Affects:** PyPy
+**Severity:** Info | **Confidence:** Medium | **Affects:** PyPy
 
 ---
 ### PPY045 — sys.settrace() disables JIT and is unreliable on PyPy
@@ -611,12 +611,12 @@ These rules detect code that behaves differently on PyPy vs CPython.
 ---
 ### PPY052 — importlib.abc resource classes may differ on PyPy
 
-**Severity:** Warning | **Confidence:** Low | **Affects:** PyPy
+**Severity:** Info | **Confidence:** Low | **Affects:** PyPy
 
 ---
 ### PPY053 — functools.lru_cache thread safety differs on PyPy
 
-**Severity:** Warning | **Confidence:** Low | **Affects:** PyPy
+**Severity:** Info | **Confidence:** Low | **Affects:** PyPy
 
 ---
 
@@ -628,6 +628,6 @@ These rules apply to both CPython and PyPy.
 
 ### PPY011 — array.array('u') type code removed in Python 3.13
 
-**Severity:** Warning | **Confidence:** High | **Affects:** CPython & PyPy
+**Severity:** Error | **Confidence:** High | **Affects:** CPython & PyPy
 
 ---

--- a/pyrift/rules/cpython/cpy001_dict_ordering.py
+++ b/pyrift/rules/cpython/cpy001_dict_ordering.py
@@ -26,6 +26,7 @@ class DictOrderingRule(BaseRule):
     rule_id = "CPY001"
     title   = "Dict ordering assumption — comparing dict view to ordered sequence"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy002_exception_notes.py
+++ b/pyrift/rules/cpython/cpy002_exception_notes.py
@@ -17,6 +17,7 @@ class ExceptionNotesRule(BaseRule):
     rule_id = "CPY002"
     title   = "Exception.add_note() requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy003_union_type_syntax.py
+++ b/pyrift/rules/cpython/cpy003_union_type_syntax.py
@@ -17,6 +17,7 @@ class UnionTypeSyntaxRule(BaseRule):
     rule_id = "CPY003"
     title   = "X | Y union type syntax requires Python 3.10+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy004_tomllib.py
+++ b/pyrift/rules/cpython/cpy004_tomllib.py
@@ -18,6 +18,7 @@ class TomllibRule(BaseRule):
     rule_id = "CPY004"
     title = "tomllib requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy005_match_case.py
+++ b/pyrift/rules/cpython/cpy005_match_case.py
@@ -17,6 +17,7 @@ class MatchCaseRule(BaseRule):
     rule_id = "CPY005"
     title   = "match/case requires Python 3.10+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy006_asyncio_timeout.py
+++ b/pyrift/rules/cpython/cpy006_asyncio_timeout.py
@@ -19,6 +19,7 @@ class AsyncioTimeoutRule(BaseRule):
     rule_id = "CPY006"
     title   = "asyncio.timeout() / TaskGroup requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy007_removed_modules.py
+++ b/pyrift/rules/cpython/cpy007_removed_modules.py
@@ -33,6 +33,7 @@ class RemovedModulesRule(BaseRule):
     rule_id = "CPY007"
     title   = "Module removed in Python 3.13"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy008_slots_dict.py
+++ b/pyrift/rules/cpython/cpy008_slots_dict.py
@@ -19,6 +19,7 @@ class SlotsDictRule(BaseRule):
     rule_id = "CPY008"
     title   = "__slots__ may not prevent __dict__ on Python < 3.10"
     runtime = "cpython"
+    severity = Severity.INFO
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy009_exception_group.py
+++ b/pyrift/rules/cpython/cpy009_exception_group.py
@@ -19,6 +19,7 @@ class ExceptionGroupRule(BaseRule):
     rule_id = "CPY009"
     title   = "ExceptionGroup requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy010_dataclass_slots.py
+++ b/pyrift/rules/cpython/cpy010_dataclass_slots.py
@@ -17,6 +17,7 @@ class DataclassSlotsRule(BaseRule):
     rule_id = "CPY010"
     title   = "@dataclass(slots=True) requires Python 3.10+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy011_typing_self.py
+++ b/pyrift/rules/cpython/cpy011_typing_self.py
@@ -13,6 +13,7 @@ class TypingSelfRule(BaseRule):
     rule_id = "CPY011"
     title = "typing.Self requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy012_literal_string.py
+++ b/pyrift/rules/cpython/cpy012_literal_string.py
@@ -13,6 +13,7 @@ class LiteralStringRule(BaseRule):
     rule_id = "CPY012"
     title = "typing.LiteralString requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy013_override.py
+++ b/pyrift/rules/cpython/cpy013_override.py
@@ -13,6 +13,7 @@ class OverrideRule(BaseRule):
     rule_id = "CPY013"
     title = "typing.override requires Python 3.12+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy014_type_alias.py
+++ b/pyrift/rules/cpython/cpy014_type_alias.py
@@ -13,6 +13,7 @@ class TypeAliasRule(BaseRule):
     rule_id = "CPY014"
     title = "typing.TypeAlias requires Python 3.10+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy015_never.py
+++ b/pyrift/rules/cpython/cpy015_never.py
@@ -13,6 +13,7 @@ class NeverRule(BaseRule):
     rule_id = "CPY015"
     title = "typing.Never requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy016_typevartuple.py
+++ b/pyrift/rules/cpython/cpy016_typevartuple.py
@@ -13,6 +13,7 @@ class TypeVarTupleRule(BaseRule):
     rule_id = "CPY016"
     title = "typing.TypeVarTuple requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy017_unpack.py
+++ b/pyrift/rules/cpython/cpy017_unpack.py
@@ -13,6 +13,7 @@ class UnpackRule(BaseRule):
     rule_id = "CPY017"
     title = "typing.Unpack requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy018_required.py
+++ b/pyrift/rules/cpython/cpy018_required.py
@@ -15,6 +15,7 @@ class RequiredRule(BaseRule):
     rule_id = "CPY018"
     title = "typing.Required / NotRequired requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy019_distutils.py
+++ b/pyrift/rules/cpython/cpy019_distutils.py
@@ -22,6 +22,7 @@ class DistutilsRule(BaseRule):
     rule_id = "CPY019"
     title = "distutils removed in Python 3.12+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy020_datetime_utc.py
+++ b/pyrift/rules/cpython/cpy020_datetime_utc.py
@@ -17,6 +17,7 @@ class DatetimeUTCRule(BaseRule):
     rule_id = "CPY020"
     title   = "datetime.UTC requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy022_bool_inversion.py
+++ b/pyrift/rules/cpython/cpy022_bool_inversion.py
@@ -18,6 +18,7 @@ class BoolInversionRule(BaseRule):
     rule_id = "CPY022"
     title   = "Bitwise inversion on bool (~True/~False) deprecated in 3.12"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy023_multiprocessing_fork.py
+++ b/pyrift/rules/cpython/cpy023_multiprocessing_fork.py
@@ -39,6 +39,7 @@ class MultiprocessingForkRule(BaseRule):
     rule_id = "CPY023"
     title = "multiprocessing default start method changing in Python 3.14"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy024_typeguard.py
+++ b/pyrift/rules/cpython/cpy024_typeguard.py
@@ -13,6 +13,7 @@ class TypeGuardRule(BaseRule):
     rule_id = "CPY024"
     title = "typing.TypeGuard requires Python 3.10+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy025_paramspec.py
+++ b/pyrift/rules/cpython/cpy025_paramspec.py
@@ -13,6 +13,7 @@ class ParamSpecRule(BaseRule):
     rule_id = "CPY025"
     title = "typing.ParamSpec requires Python 3.10+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy026_typing_io_re.py
+++ b/pyrift/rules/cpython/cpy026_typing_io_re.py
@@ -15,6 +15,7 @@ class TypingIoReRule(BaseRule):
     rule_id = "CPY026"
     title = "typing.io and typing.re removed in Python 3.13"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy027_locale_resetlocale.py
+++ b/pyrift/rules/cpython/cpy027_locale_resetlocale.py
@@ -17,6 +17,7 @@ class LocaleResetlocaleRule(BaseRule):
     rule_id = "CPY027"
     title   = "locale.resetlocale() removed in Python 3.13"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy028_lib2to3.py
+++ b/pyrift/rules/cpython/cpy028_lib2to3.py
@@ -13,6 +13,7 @@ class Lib2to3Rule(BaseRule):
     rule_id = "CPY028"
     title = "lib2to3 removed in Python 3.13"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy029_locals_behaviour.py
+++ b/pyrift/rules/cpython/cpy029_locals_behaviour.py
@@ -33,6 +33,7 @@ class LocalsBehaviourRule(BaseRule):
     rule_id = "CPY029"
     title   = "locals() semantics changed in Python 3.13 (PEP 667)"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy030_sys_path_bytes.py
+++ b/pyrift/rules/cpython/cpy030_sys_path_bytes.py
@@ -19,6 +19,7 @@ class SysPathBytesRule(BaseRule):
     rule_id = "CPY030"
     title   = "sys.path no longer accepts bytes entries in Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy031_assert_never.py
+++ b/pyrift/rules/cpython/cpy031_assert_never.py
@@ -13,6 +13,7 @@ class AssertNeverRule(BaseRule):
     rule_id = "CPY031"
     title = "typing.assert_never requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy032_reveal_type.py
+++ b/pyrift/rules/cpython/cpy032_reveal_type.py
@@ -13,6 +13,7 @@ class RevealTypeRule(BaseRule):
     rule_id = "CPY032"
     title = "typing.reveal_type requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy033_is_relative_to.py
+++ b/pyrift/rules/cpython/cpy033_is_relative_to.py
@@ -17,6 +17,7 @@ class IsRelativeToRule(BaseRule):
     rule_id = "CPY033"
     title   = "pathlib.Path.is_relative_to() requires Python 3.9+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def _is_version_guarded(self, node: ast.AST, tree: ast.AST) -> bool:
         """Return True if *node* is inside a sys.version_info >= (3, 9) guard."""

--- a/pyrift/rules/cpython/cpy034_bit_count.py
+++ b/pyrift/rules/cpython/cpy034_bit_count.py
@@ -17,6 +17,7 @@ class BitCountRule(BaseRule):
     rule_id = "CPY034"
     title   = "int.bit_count() requires Python 3.10+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def _is_version_guarded(self, node: ast.AST, tree: ast.AST) -> bool:
         """Return True if *node* is inside a sys.version_info >= (3, 10) guard."""

--- a/pyrift/rules/cpython/cpy035_removeprefix.py
+++ b/pyrift/rules/cpython/cpy035_removeprefix.py
@@ -19,6 +19,7 @@ class RemovePrefixRule(BaseRule):
     rule_id = "CPY035"
     title   = "str.removeprefix/removesuffix requires Python 3.9+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def _is_version_guarded(self, node: ast.AST, tree: ast.AST) -> bool:
         """Return True if *node* is inside a sys.version_info >= (3, 9) guard."""

--- a/pyrift/rules/cpython/cpy036_datetime_utcnow.py
+++ b/pyrift/rules/cpython/cpy036_datetime_utcnow.py
@@ -18,6 +18,7 @@ class DatetimeUtcnowRule(BaseRule):
     rule_id = "CPY036"
     title   = "datetime.utcnow() deprecated since Python 3.12"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy037_datetime_utcfromtimestamp.py
+++ b/pyrift/rules/cpython/cpy037_datetime_utcfromtimestamp.py
@@ -18,6 +18,7 @@ class DatetimeUtcfromtimestampRule(BaseRule):
     rule_id = "CPY037"
     title   = "datetime.utcfromtimestamp() deprecated since Python 3.12"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy038_asyncio_get_event_loop.py
+++ b/pyrift/rules/cpython/cpy038_asyncio_get_event_loop.py
@@ -22,6 +22,7 @@ class AsyncioGetEventLoopRule(BaseRule):
     rule_id = "CPY038"
     title = "asyncio.get_event_loop() raises RuntimeError in Python 3.14+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy039_zoneinfo.py
+++ b/pyrift/rules/cpython/cpy039_zoneinfo.py
@@ -18,6 +18,7 @@ class ZoneInfoRule(BaseRule):
     rule_id = "CPY039"
     title = "zoneinfo module requires Python 3.9+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy040_graphlib.py
+++ b/pyrift/rules/cpython/cpy040_graphlib.py
@@ -18,6 +18,7 @@ class GraphlibRule(BaseRule):
     rule_id = "CPY040"
     title = "graphlib module requires Python 3.9+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy041_dict_merge_operator.py
+++ b/pyrift/rules/cpython/cpy041_dict_merge_operator.py
@@ -43,6 +43,7 @@ class DictMergeOperatorRule(BaseRule):
     rule_id = "CPY041"
     title   = "dict | merge operator requires Python 3.9+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy042_aiter_anext.py
+++ b/pyrift/rules/cpython/cpy042_aiter_anext.py
@@ -20,6 +20,7 @@ class AiterAnextRule(BaseRule):
     rule_id = "CPY042"
     title   = "aiter() and anext() builtins require Python 3.10+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy043_math_lcm.py
+++ b/pyrift/rules/cpython/cpy043_math_lcm.py
@@ -17,6 +17,7 @@ class MathLcmRule(BaseRule):
     rule_id = "CPY043"
     title   = "math.lcm() requires Python 3.9+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy044_math_gcd_multi.py
+++ b/pyrift/rules/cpython/cpy044_math_gcd_multi.py
@@ -18,6 +18,7 @@ class MathGcdMultiRule(BaseRule):
     rule_id = "CPY044"
     title   = "math.gcd() with multiple args requires Python 3.9+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy045_nan_hash.py
+++ b/pyrift/rules/cpython/cpy045_nan_hash.py
@@ -19,6 +19,7 @@ class NanHashRule(BaseRule):
     rule_id = "CPY045"
     title   = "NaN hash behaviour changed in Python 3.10"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy046_open_encoding.py
+++ b/pyrift/rules/cpython/cpy046_open_encoding.py
@@ -25,6 +25,7 @@ class OpenEncodingRule(BaseRule):
     rule_id = "CPY046"
     title   = "open() without encoding= uses platform-dependent encoding before 3.15"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def _is_stdstream(self, node: ast.Call) -> bool:
         """Return True if the first argument is sys.stdin/stdout/stderr."""

--- a/pyrift/rules/cpython/cpy047_bytesstring_removed.py
+++ b/pyrift/rules/cpython/cpy047_bytesstring_removed.py
@@ -19,6 +19,7 @@ class ByteStringRemovedRule(BaseRule):
     rule_id = "CPY047"
     title   = "collections.abc.ByteString deprecated, scheduled removal in Python 3.17"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy048_concurrent_interpreters.py
+++ b/pyrift/rules/cpython/cpy048_concurrent_interpreters.py
@@ -13,6 +13,7 @@ class ConcurrentInterpretersRule(BaseRule):
     rule_id = "CPY048"
     title = "concurrent.interpreters requires Python 3.14+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy049_compression_zstd.py
+++ b/pyrift/rules/cpython/cpy049_compression_zstd.py
@@ -13,6 +13,7 @@ class CompressionZstdRule(BaseRule):
     rule_id = "CPY049"
     title = "compression.zstd requires Python 3.14+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy050_purepath_is_reserved.py
+++ b/pyrift/rules/cpython/cpy050_purepath_is_reserved.py
@@ -20,6 +20,7 @@ class PurePathIsReservedRule(BaseRule):
     rule_id = "CPY050"
     title = "PurePath.is_reserved() deprecated in 3.13, removed in 3.15"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy051_free_threaded_global_state.py
+++ b/pyrift/rules/cpython/cpy051_free_threaded_global_state.py
@@ -256,6 +256,7 @@ class FreeThreadedGlobalStateRule(BaseRule):
         "in free-threaded Python"
     )
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy053_typing_get_overloads.py
+++ b/pyrift/rules/cpython/cpy053_typing_get_overloads.py
@@ -17,6 +17,7 @@ class TypingGetOverloadsRule(BaseRule):
     rule_id = "CPY053"
     title   = "typing.get_overloads() requires Python 3.11+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy054_int_trunc.py
+++ b/pyrift/rules/cpython/cpy054_int_trunc.py
@@ -19,6 +19,7 @@ class IntTruncRule(BaseRule):
     rule_id = "CPY054"
     title   = "int() no longer delegates to __trunc__() in Python 3.14"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy055_notimplemented_bool.py
+++ b/pyrift/rules/cpython/cpy055_notimplemented_bool.py
@@ -18,6 +18,7 @@ class NotImplementedBoolRule(BaseRule):
     rule_id = "CPY055"
     title   = "NotImplemented in boolean context raises TypeError in Python 3.14"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy057_pickle_protocol.py
+++ b/pyrift/rules/cpython/cpy057_pickle_protocol.py
@@ -85,6 +85,7 @@ class PickleProtocolRule(BaseRule):
     rule_id = "CPY057"
     title = "pickle default protocol changed to 5 in Python 3.14"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy062_template_string.py
+++ b/pyrift/rules/cpython/cpy062_template_string.py
@@ -13,6 +13,7 @@ class TemplateStringRule(BaseRule):
     rule_id = "CPY062"
     title = "string.templatelib requires Python 3.14+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy063_annotationlib.py
+++ b/pyrift/rules/cpython/cpy063_annotationlib.py
@@ -13,6 +13,7 @@ class AnnotationLibRule(BaseRule):
     rule_id = "CPY063"
     title = "annotationlib requires Python 3.14+"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy064_ast_deprecated_nodes.py
+++ b/pyrift/rules/cpython/cpy064_ast_deprecated_nodes.py
@@ -31,6 +31,7 @@ class AstDeprecatedNodesRule(BaseRule):
     rule_id = "CPY064"
     title   = "Deprecated AST node types removed in Python 3.14"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy065_pkgutil_find_loader.py
+++ b/pyrift/rules/cpython/cpy065_pkgutil_find_loader.py
@@ -26,6 +26,7 @@ class PkgutilFindLoaderRule(BaseRule):
     rule_id = "CPY065"
     title   = "pkgutil.find_loader()/get_loader() removed in Python 3.14"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy066_asyncio_child_watcher.py
+++ b/pyrift/rules/cpython/cpy066_asyncio_child_watcher.py
@@ -33,6 +33,7 @@ class AsyncioChildWatcherRule(BaseRule):
     rule_id = "CPY066"
     title   = "asyncio child watcher classes removed in Python 3.14"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy067_typing_namedtuple_keyword.py
+++ b/pyrift/rules/cpython/cpy067_typing_namedtuple_keyword.py
@@ -28,6 +28,7 @@ class TypingNamedTupleKeywordRule(BaseRule):
     rule_id = "CPY067"
     title = "typing.NamedTuple keyword syntax removed in Python 3.15"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(self, node: ast.AST, filename: str, target_config=None) -> list[Finding]:
         findings: list[Finding] = []

--- a/pyrift/rules/cpython/cpy068_typing_no_type_check_decorator.py
+++ b/pyrift/rules/cpython/cpy068_typing_no_type_check_decorator.py
@@ -22,6 +22,7 @@ class TypingNoTypeCheckDecoratorRule(BaseRule):
     rule_id = "CPY068"
     title   = "typing.no_type_check_decorator deprecated in 3.13, removed in 3.15"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy069_asyncio_iscoroutinefunction.py
+++ b/pyrift/rules/cpython/cpy069_asyncio_iscoroutinefunction.py
@@ -22,6 +22,7 @@ class AsyncioIscoroutinefunctionRule(BaseRule):
     rule_id = "CPY069"
     title   = "asyncio.iscoroutinefunction() deprecated in Python 3.14"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy070_asyncio_event_loop_policy.py
+++ b/pyrift/rules/cpython/cpy070_asyncio_event_loop_policy.py
@@ -28,6 +28,7 @@ class AsyncioEventLoopPolicyRule(BaseRule):
     rule_id = "CPY070"
     title   = "asyncio event loop policy deprecated in Python 3.14"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy071_pty_master_slave_open.py
+++ b/pyrift/rules/cpython/cpy071_pty_master_slave_open.py
@@ -26,6 +26,7 @@ class PtyMasterSlaveOpenRule(BaseRule):
     rule_id = "CPY071"
     title   = "pty.master_open()/slave_open() removed in Python 3.14"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy072_importlib_abc_resource.py
+++ b/pyrift/rules/cpython/cpy072_importlib_abc_resource.py
@@ -26,6 +26,7 @@ class ImportlibAbcResourceRule(BaseRule):
     rule_id = "CPY072"
     title   = "importlib.abc resource classes removed in Python 3.14"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy073_sqlite3_version.py
+++ b/pyrift/rules/cpython/cpy073_sqlite3_version.py
@@ -24,6 +24,7 @@ class Sqlite3VersionRemovedRule(BaseRule):
     rule_id = "CPY073"
     title   = "sqlite3.version/version_info removed in Python 3.14"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy074_co_lnotab_deprecated.py
+++ b/pyrift/rules/cpython/cpy074_co_lnotab_deprecated.py
@@ -23,6 +23,7 @@ class CoLnotabDeprecatedRule(BaseRule):
     rule_id = "CPY074"
     title   = "code.__lnotab__ deprecated since Python 3.10 (PEP 626)"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy075_http_server_cgi.py
+++ b/pyrift/rules/cpython/cpy075_http_server_cgi.py
@@ -23,6 +23,7 @@ class HttpServerCGIHandlerRule(BaseRule):
     rule_id = "CPY075"
     title   = "http.server.CGIHTTPRequestHandler deprecated in 3.13, removed in 3.15"
     runtime = "cpython"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy076_ssl_wrap_socket.py
+++ b/pyrift/rules/cpython/cpy076_ssl_wrap_socket.py
@@ -22,6 +22,7 @@ class SslWrapSocketRule(BaseRule):
     rule_id = "CPY076"
     title   = "ssl.wrap_socket() removed in Python 3.12"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/cpython/cpy077_typing_typeddict_functional.py
+++ b/pyrift/rules/cpython/cpy077_typing_typeddict_functional.py
@@ -28,6 +28,7 @@ class TypingTypedDictFunctionalRule(BaseRule):
     rule_id = "CPY077"
     title = "typing.TypedDict zero-field syntax removed in Python 3.15"
     runtime = "cpython"
+    severity = Severity.ERROR
 
     def check(self, node: ast.AST, filename: str, target_config=None) -> list[Finding]:
         findings: list[Finding] = []

--- a/pyrift/rules/pypy/ppy001_gc_finalizer.py
+++ b/pyrift/rules/pypy/ppy001_gc_finalizer.py
@@ -19,6 +19,7 @@ class GcFinalizerRule(BaseRule):
     rule_id = "PPY001"
     title   = "Relying on __del__ for resource cleanup breaks on PyPy"
     runtime = "pypy"
+    severity = Severity.ERROR
 
     RESOURCE_PATTERNS: ClassVar[set[str]] = {
         "close",

--- a/pyrift/rules/pypy/ppy002_ctypes.py
+++ b/pyrift/rules/pypy/ppy002_ctypes.py
@@ -27,6 +27,7 @@ class CtypesRule(BaseRule):
     rule_id = "PPY002"
     title   = "ctypes usage may silently fail on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy003_getrefcount.py
+++ b/pyrift/rules/pypy/ppy003_getrefcount.py
@@ -19,6 +19,7 @@ class GetRefcountRule(BaseRule):
     rule_id = "PPY003"
     title   = "sys.getrefcount() is meaningless on PyPy"
     runtime = "pypy"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy004_weakref_proxy.py
+++ b/pyrift/rules/pypy/ppy004_weakref_proxy.py
@@ -20,6 +20,7 @@ class WeakrefProxyRule(BaseRule):
     rule_id = "PPY004"
     title   = "weakref.proxy() lifetime differs on PyPy due to GC model"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy005_io_buffering.py
+++ b/pyrift/rules/pypy/ppy005_io_buffering.py
@@ -16,6 +16,7 @@ class IoBufferingRule(BaseRule):
     rule_id = "PPY005"
     title = "File write without explicit lifecycle management on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     @staticmethod
     def _is_write_mode(mode: str) -> bool:

--- a/pyrift/rules/pypy/ppy006_builtin_monkey_patch.py
+++ b/pyrift/rules/pypy/ppy006_builtin_monkey_patch.py
@@ -24,6 +24,7 @@ class BuiltinMonkeyPatchRule(BaseRule):
     rule_id = "PPY006"
     title   = "Monkey-patching built-in types behaves differently on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy007_sys_intern.py
+++ b/pyrift/rules/pypy/ppy007_sys_intern.py
@@ -20,6 +20,7 @@ class SysInternRule(BaseRule):
     rule_id = "PPY007"
     title   = "sys.intern() identity guarantees differ on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy008_threading_local.py
+++ b/pyrift/rules/pypy/ppy008_threading_local.py
@@ -19,6 +19,7 @@ class ThreadingLocalRule(BaseRule):
     rule_id = "PPY008"
     title   = "threading.local() cleanup timing differs on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy009_id_stability.py
+++ b/pyrift/rules/pypy/ppy009_id_stability.py
@@ -289,6 +289,7 @@ class IdStabilityRule(BaseRule):
     rule_id = "PPY009"
     title = "id() stability depends on PyPy GC configuration"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
             self,

--- a/pyrift/rules/pypy/ppy010_gc_collect.py
+++ b/pyrift/rules/pypy/ppy010_gc_collect.py
@@ -21,6 +21,7 @@ class GcCollectRule(BaseRule):
     rule_id = "PPY010"
     title   = "gc.collect() behaviour differs on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy011_array.py
+++ b/pyrift/rules/pypy/ppy011_array.py
@@ -19,6 +19,7 @@ class ArrayTypeCodeRule(BaseRule):
     rule_id = "PPY011"
     title   = "array.array('u') type code removed in Python 3.13"
     runtime = "both"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy012_subclassing_builtins.py
+++ b/pyrift/rules/pypy/ppy012_subclassing_builtins.py
@@ -32,6 +32,7 @@ class SubclassingBuiltinsRule(BaseRule):
     rule_id = "PPY012"
     title   = "Overriding built-in methods may behave differently on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy013_getsizeof.py
+++ b/pyrift/rules/pypy/ppy013_getsizeof.py
@@ -19,6 +19,7 @@ class GetSizeofRule(BaseRule):
     rule_id = "PPY013"
     title   = "sys.getsizeof() raises TypeError on PyPy"
     runtime = "pypy"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy014_string_concat.py
+++ b/pyrift/rules/pypy/ppy014_string_concat.py
@@ -24,6 +24,7 @@ class StringConcatLoopRule(BaseRule):
     rule_id = "PPY014"
     title = "String concatenation in loop is O(n²) on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     @staticmethod
     def _is_string_value(node: ast.AST | None) -> bool:

--- a/pyrift/rules/pypy/ppy015_generator_gc.py
+++ b/pyrift/rules/pypy/ppy015_generator_gc.py
@@ -19,6 +19,7 @@ class GeneratorGCRule(BaseRule):
     rule_id = "PPY015"
     title   = "Generator cleanup timing differs on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy016_instance_dict_order.py
+++ b/pyrift/rules/pypy/ppy016_instance_dict_order.py
@@ -63,6 +63,7 @@ class InstanceDictOrderRule(BaseRule):
     rule_id = "PPY016"
     title = "Instance __dict__ order-sensitive access may differ on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
             self,

--- a/pyrift/rules/pypy/ppy017_del_existing_class.py
+++ b/pyrift/rules/pypy/ppy017_del_existing_class.py
@@ -18,6 +18,7 @@ class DelExistingClassRule(BaseRule):
     rule_id = "PPY017"
     title   = "Adding __del__ to existing class not called on PyPy"
     runtime = "pypy"
+    severity = Severity.ERROR
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy018_recursion_limit.py
+++ b/pyrift/rules/pypy/ppy018_recursion_limit.py
@@ -20,6 +20,7 @@ class RecursionLimitRule(BaseRule):
     rule_id = "PPY018"
     title   = "sys.setrecursionlimit() behaviour differs on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy019_nan_identity.py
+++ b/pyrift/rules/pypy/ppy019_nan_identity.py
@@ -19,6 +19,7 @@ class NanIdentityRule(BaseRule):
     rule_id = "PPY019"
     title   = "float('nan') identity differs between CPython and PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy021_socket_gc.py
+++ b/pyrift/rules/pypy/ppy021_socket_gc.py
@@ -19,6 +19,7 @@ class SocketGCRule(BaseRule):
     rule_id = "PPY021"
     title   = "Socket not closed promptly on PyPy — GC timing"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def _is_in_context_manager(self, node: ast.AST, tree: ast.AST) -> bool:
         """Return True if *node* is nested inside a ``with`` statement."""

--- a/pyrift/rules/pypy/ppy022_hash_randomisation.py
+++ b/pyrift/rules/pypy/ppy022_hash_randomisation.py
@@ -20,6 +20,7 @@ class HashRandomisationRule(BaseRule):
     rule_id = "PPY022"
     title   = "PYTHONHASHSEED=0 has no effect on PyPy hash randomisation"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy023_inspect_ismethod.py
+++ b/pyrift/rules/pypy/ppy023_inspect_ismethod.py
@@ -20,6 +20,7 @@ class InspectIsMethodRule(BaseRule):
     rule_id = "PPY023"
     title   = "inspect.ismethod() returns different results on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy024_timeit.py
+++ b/pyrift/rules/pypy/ppy024_timeit.py
@@ -21,6 +21,7 @@ class TimeitRule(BaseRule):
     rule_id = "PPY024"
     title   = "timeit reports average not minimum on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy025_set_ordering.py
+++ b/pyrift/rules/pypy/ppy025_set_ordering.py
@@ -18,6 +18,7 @@ class SetOrderingRule(BaseRule):
     rule_id = "PPY025"
     title   = "Set iteration order differs between CPython and PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy026_builtins_module.py
+++ b/pyrift/rules/pypy/ppy026_builtins_module.py
@@ -19,6 +19,7 @@ class BuiltinsModuleRule(BaseRule):
     rule_id = "PPY026"
     title   = "__builtins__ is always a module on PyPy, never a dict"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def _is_version_guarded(self, node: ast.AST, tree: ast.AST) -> bool:
         """Return True if *node* is inside a sys.version_info check."""

--- a/pyrift/rules/pypy/ppy027_module_attr_delete.py
+++ b/pyrift/rules/pypy/ppy027_module_attr_delete.py
@@ -17,6 +17,7 @@ class ModuleAttrDeleteRule(BaseRule):
     rule_id = "PPY027"
     title = "Deleting module/class attributes may be slower on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def check(
             self,

--- a/pyrift/rules/pypy/ppy028_readline_parse_bind.py
+++ b/pyrift/rules/pypy/ppy028_readline_parse_bind.py
@@ -19,6 +19,7 @@ class ReadlineParseBindRule(BaseRule):
     rule_id = "PPY028"
     title   = "readline.parse_and_bind() silently ignored on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy029_builtins_assign.py
+++ b/pyrift/rules/pypy/ppy029_builtins_assign.py
@@ -19,6 +19,7 @@ class BuiltinsAssignRule(BaseRule):
     rule_id = "PPY029"
     title   = "Assigning to __builtins__ has no effect on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy030_sys_flags.py
+++ b/pyrift/rules/pypy/ppy030_sys_flags.py
@@ -25,6 +25,7 @@ class SysFlagsRule(BaseRule):
     rule_id = "PPY030"
     title   = "sys.flags values may differ between CPython and PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy031_integer_identity.py
+++ b/pyrift/rules/pypy/ppy031_integer_identity.py
@@ -29,6 +29,7 @@ class IntegerIdentityRule(BaseRule):
     rule_id = "PPY031"
     title = "Integer 'is' identity semantics differ on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     @staticmethod
     def _looks_like_integer(node: ast.AST) -> bool:

--- a/pyrift/rules/pypy/ppy032_dict_key_mutation.py
+++ b/pyrift/rules/pypy/ppy032_dict_key_mutation.py
@@ -20,6 +20,7 @@ class DictKeyMutationRule(BaseRule):
     rule_id = "PPY032"
     title   = "Mutating dict keys raises RuntimeError on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy033_del_ignored_exceptions.py
+++ b/pyrift/rules/pypy/ppy033_del_ignored_exceptions.py
@@ -20,6 +20,7 @@ class DelIgnoredExceptionsRule(BaseRule):
     rule_id = "PPY033"
     title   = "Exceptions in __del__ appear at unpredictable times on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy034_hash_minus_one.py
+++ b/pyrift/rules/pypy/ppy034_hash_minus_one.py
@@ -31,6 +31,7 @@ class HashMinusOneRule(BaseRule):
     rule_id = "PPY034"
     title   = "hash() values may differ between CPython and PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy035_c_extensions.py
+++ b/pyrift/rules/pypy/ppy035_c_extensions.py
@@ -25,6 +25,7 @@ class CExtensionsRule(BaseRule):
     rule_id = "PPY035"
     title = "C extension packages may not work correctly on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy036_open_flush.py
+++ b/pyrift/rules/pypy/ppy036_open_flush.py
@@ -19,6 +19,7 @@ class OpenFlushRule(BaseRule):
     rule_id = "PPY036"
     title   = "open() line buffering behaves differently on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy037_os_urandom.py
+++ b/pyrift/rules/pypy/ppy037_os_urandom.py
@@ -20,6 +20,7 @@ class OsUrandomRule(BaseRule):
     rule_id = "PPY037"
     title   = "os.urandom() source may differ on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy038_decimal.py
+++ b/pyrift/rules/pypy/ppy038_decimal.py
@@ -27,6 +27,7 @@ class DecimalBackendRule(BaseRule):
     rule_id = "PPY038"
     title   = "decimal module uses different backend on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy039_os_fork.py
+++ b/pyrift/rules/pypy/ppy039_os_fork.py
@@ -20,6 +20,7 @@ class OsForkRule(BaseRule):
     rule_id = "PPY039"
     title   = "os.fork() may not work correctly on all PyPy platforms"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy040_subprocess_pipe.py
+++ b/pyrift/rules/pypy/ppy040_subprocess_pipe.py
@@ -20,6 +20,7 @@ class SubprocessPipeRule(BaseRule):
     rule_id = "PPY040"
     title   = "subprocess.PIPE buffering may cause deadlocks on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy041_dict_merge_pypy.py
+++ b/pyrift/rules/pypy/ppy041_dict_merge_pypy.py
@@ -23,6 +23,7 @@ class DictMergePypyRule(BaseRule):
     rule_id = "PPY041"
     title = "dict | operator requires PyPy 7.3.7+ (Python 3.9 compat)"
     runtime = "pypy"
+    severity = Severity.INFO
 
     @staticmethod
     def _is_dict_constructor(node: ast.AST) -> bool:

--- a/pyrift/rules/pypy/ppy042_print_flush.py
+++ b/pyrift/rules/pypy/ppy042_print_flush.py
@@ -19,6 +19,7 @@ class PrintFlushRule(BaseRule):
     rule_id = "PPY042"
     title   = "print(flush=True) may not flush immediately on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy044_exception_chaining.py
+++ b/pyrift/rules/pypy/ppy044_exception_chaining.py
@@ -26,6 +26,7 @@ class ExceptionChainingRule(BaseRule):
     rule_id = "PPY044"
     title = "Exception variable cleanup timing differs on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     @staticmethod
     def _name_used_in_node(

--- a/pyrift/rules/pypy/ppy045_sys_settrace.py
+++ b/pyrift/rules/pypy/ppy045_sys_settrace.py
@@ -20,6 +20,7 @@ class SysSettraceRule(BaseRule):
     rule_id = "PPY045"
     title   = "sys.settrace() disables JIT and is unreliable on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy047_ctypes_find_library.py
+++ b/pyrift/rules/pypy/ppy047_ctypes_find_library.py
@@ -56,6 +56,7 @@ class CtypesFindLibraryRule(BaseRule):
     rule_id = "PPY047"
     title   = "ctypes.util.find_library() unreliable on PyPy"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy049_gc_behavior.py
+++ b/pyrift/rules/pypy/ppy049_gc_behavior.py
@@ -24,6 +24,7 @@ class GcBehaviorRule(BaseRule):
     rule_id = "PPY049"
     title = "GC behavior differs between PyPy and CPython"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     _GC_FUNCTIONS = frozenset(
         {

--- a/pyrift/rules/pypy/ppy051_co_lnotab.py
+++ b/pyrift/rules/pypy/ppy051_co_lnotab.py
@@ -23,6 +23,7 @@ class CoLnotabPyPyRule(BaseRule):
     rule_id = "PPY051"
     title   = "code.__lnotab__ deprecated on PyPy too"
     runtime = "pypy"
+    severity = Severity.WARNING
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy052_importlib_abc.py
+++ b/pyrift/rules/pypy/ppy052_importlib_abc.py
@@ -25,6 +25,7 @@ class ImportlibAbcPyPyRule(BaseRule):
     rule_id = "PPY052"
     title   = "importlib.abc resource classes may differ on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def check(
         self,

--- a/pyrift/rules/pypy/ppy053_lru_cache_thread_safety.py
+++ b/pyrift/rules/pypy/ppy053_lru_cache_thread_safety.py
@@ -24,6 +24,7 @@ class LruCacheThreadSafetyRule(BaseRule):
     rule_id = "PPY053"
     title   = "functools.lru_cache thread safety differs on PyPy"
     runtime = "pypy"
+    severity = Severity.INFO
 
     def _is_lru_cache(self, node: ast.expr) -> bool:
         """Return True if the node represents functools.lru_cache or lru_cache."""


### PR DESCRIPTION
- Make severity explicit on all registered rules.
- Stabilize PPY049 GC behavior detection.
- Keep generated rule documentation consistent with the authoritative rule metadata.

## Validation

- 1227 tests passing
- 267/267 benchmark cases passing
- 118/118 golden rules covered
- Ruff clean
- Documentation checks clean
- git diff --check clean"